### PR TITLE
Add execute current expression feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.2",
         "codemirror": "^6.0.1",
+        "codemirror-lang-r": "^0.1.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "webr": "^0.5.6"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.2",
     "codemirror": "^6.0.1",
+    "codemirror-lang-r": "^0.1.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "webr": "^0.5.6"

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -29,7 +29,7 @@ import {
   closeBracketsKeymap,
 } from "@codemirror/autocomplete";
 import { lintKeymap } from "@codemirror/lint";
-import { javascript } from "@codemirror/lang-javascript";
+import { r } from "codemirror-lang-r";
 import {
   resultGroupingExtension,
   setLineGroups,
@@ -140,7 +140,7 @@ export function Editor({
           ...completionKeymap,
           ...lintKeymap,
         ]),
-        javascript(),
+        r(),
         resultGroupingExtension,
         lineGroupLayoutExtension,
         debugPanelExtension(),

--- a/src/TopBar.tsx
+++ b/src/TopBar.tsx
@@ -3,12 +3,14 @@ import React from "react";
 interface TopBarProps {
   isWebRReady: boolean;
   onRunAll: () => void;
+  onRunCurrent: () => void;
   initMessage?: string;
 }
 
-export function TopBar({ isWebRReady, onRunAll, initMessage }: TopBarProps) {
+export function TopBar({ isWebRReady, onRunAll, onRunCurrent, initMessage }: TopBarProps) {
   const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
-  const shortcut = isMac ? "CMD+ENTER" : "CTRL+ENTER";
+  const currentShortcut = isMac ? "CMD+ENTER" : "CTRL+ENTER";
+  const allShortcut = isMac ? "CMD+SHIFT+ENTER" : "CTRL+SHIFT+ENTER";
 
   return (
     <div className="top-bar">
@@ -16,11 +18,19 @@ export function TopBar({ isWebRReady, onRunAll, initMessage }: TopBarProps) {
         <div className="top-bar-left">
           <button
             className="run-all-button"
+            onClick={onRunCurrent}
+            disabled={!isWebRReady}
+            title={`Run current expression (${currentShortcut})`}
+          >
+            ▶ RUN CURRENT ({currentShortcut})
+          </button>
+          <button
+            className="run-all-button"
             onClick={onRunAll}
             disabled={!isWebRReady}
-            title={`Run all code (${shortcut})`}
+            title={`Run all code (${allShortcut})`}
           >
-            ▶ RUN ALL ({shortcut})
+            ▶ RUN ALL ({allShortcut})
           </button>
         </div>
         <div className="top-bar-right">

--- a/src/execution-gutter.ts
+++ b/src/execution-gutter.ts
@@ -1,0 +1,143 @@
+import { EditorView, Decoration, DecorationSet } from "@codemirror/view";
+import { StateField, StateEffect } from "@codemirror/state";
+import { LineGroup } from "./compute-line-groups";
+
+// Execution history tracking
+// - everExecuted: all line groups that have been executed at some point
+// - lastExecuted: line groups executed in the last request
+interface ExecutionHistory {
+  everExecuted: LineGroup[];
+  lastExecuted: LineGroup[];
+}
+
+// StateEffect to update execution history
+export const updateExecutionHistory = StateEffect.define<LineGroup[]>();
+
+// Helper to check if two line groups overlap or match
+function lineGroupsMatch(a: LineGroup, b: LineGroup): boolean {
+  return a.lineStart === b.lineStart && a.lineEnd === b.lineEnd;
+}
+
+// StateField to track execution history (exported so other modules can read it)
+export const executionHistoryField = StateField.define<ExecutionHistory>({
+  create() {
+    return {
+      everExecuted: [],
+      lastExecuted: [],
+    };
+  },
+
+  update(history, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(updateExecutionHistory)) {
+        const newGroups = effect.value;
+
+        // Add previous lastExecuted to everExecuted
+        const updatedEverExecuted = [...history.everExecuted];
+        for (const oldGroup of history.lastExecuted) {
+          const exists = updatedEverExecuted.some(g => lineGroupsMatch(g, oldGroup));
+          if (!exists) {
+            updatedEverExecuted.push(oldGroup);
+          }
+        }
+
+        // Merge new groups into everExecuted (deduplicate by line range)
+        for (const newGroup of newGroups) {
+          const exists = updatedEverExecuted.some(g => lineGroupsMatch(g, newGroup));
+          if (!exists) {
+            updatedEverExecuted.push(newGroup);
+          }
+        }
+
+        // Replace lastExecuted with only the new groups
+        return {
+          everExecuted: updatedEverExecuted,
+          lastExecuted: newGroups,
+        };
+      }
+    }
+    return history;
+  },
+});
+
+// Build DecorationSet of line decorations based on execution history
+const executionDecorationField = StateField.define<DecorationSet>({
+  create() {
+    return Decoration.none;
+  },
+
+  update(_, tr) {
+    const history = tr.state.field(executionHistoryField);
+    const doc = tr.state.doc;
+    const decorations: any[] = [];
+
+    // Build sets of line numbers for quick lookup
+    const lastExecutedLines = new Set<number>();
+    for (const group of history.lastExecuted) {
+      for (let lineNum = group.lineStart; lineNum <= group.lineEnd; lineNum++) {
+        lastExecutedLines.add(lineNum);
+      }
+    }
+
+    const everExecutedLines = new Set<number>();
+    for (const group of history.everExecuted) {
+      for (let lineNum = group.lineStart; lineNum <= group.lineEnd; lineNum++) {
+        everExecutedLines.add(lineNum);
+      }
+    }
+
+    // Add decorations for all lines in everExecuted
+    for (let lineNum = 1; lineNum <= doc.lines; lineNum++) {
+      try {
+        const line = doc.line(lineNum);
+
+        // If in lastExecuted → dark blue (takes priority)
+        if (lastExecutedLines.has(lineNum)) {
+          decorations.push(
+            Decoration.line({ class: "cm-execution-recent" }).range(line.from)
+          );
+        }
+        // Else if in everExecuted → light blue
+        else if (everExecutedLines.has(lineNum)) {
+          decorations.push(
+            Decoration.line({ class: "cm-execution-previous" }).range(line.from)
+          );
+        }
+      } catch (e) {
+        continue;
+      }
+    }
+
+    return decorations.length === 0
+      ? Decoration.none
+      : Decoration.set(decorations, true);
+  },
+
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+// Theme for execution state decorations
+const executionTheme = EditorView.theme({
+  ".cm-execution-recent": {
+    borderLeft: "4px solid #0066cc",
+    paddingLeft: "2px",
+  },
+  ".cm-execution-previous": {
+    borderLeft: "4px solid #99ccff",
+    paddingLeft: "2px",
+  },
+});
+
+// Export the execution state extension
+export const executionGutterExtension = [
+  executionHistoryField,
+  executionDecorationField,
+  executionTheme,
+];
+
+// Export function to update execution history from outside
+export function setExecutionHistory(view: EditorView, lineGroups: LineGroup[]) {
+  view.dispatch({
+    effects: updateExecutionHistory.of(lineGroups),
+  });
+}

--- a/src/expression-finder.ts
+++ b/src/expression-finder.ts
@@ -1,0 +1,68 @@
+import { getWebR } from './webr-instance';
+
+export interface ExpressionInfo {
+  index: number;      // 1-based index for R
+  lineStart: number;
+  lineEnd: number;
+}
+
+/**
+ * Find which R expression contains the given cursor line.
+ * Returns the expression index (1-based) and its line range.
+ */
+export async function findExpressionAtLine(
+  script: string,
+  cursorLine: number
+): Promise<ExpressionInfo | null> {
+  const webR = getWebR();
+
+  try {
+    // Parse the code and get expression boundaries
+    await webR.evalRVoid(`
+      .rdit_code <- ${JSON.stringify(script)}
+      .rdit_parsed <- parse(text = .rdit_code, keep.source = TRUE)
+      .rdit_parse_data <- getParseData(.rdit_parsed)
+    `);
+
+    const numExpressions = await webR.evalRNumber('length(.rdit_parsed)');
+
+    // Find the expression that contains the cursor line
+    for (let i = 1; i <= numExpressions; i++) {
+      const startLine = await webR.evalRNumber(`
+        {
+          top_level_exprs <- .rdit_parse_data[.rdit_parse_data$parent == 0 & .rdit_parse_data$token == "expr", ]
+          if (nrow(top_level_exprs) >= ${i}) {
+            top_level_exprs$line1[${i}]
+          } else {
+            NA
+          }
+        }
+      `);
+
+      const endLine = await webR.evalRNumber(`
+        {
+          top_level_exprs <- .rdit_parse_data[.rdit_parse_data$parent == 0 & .rdit_parse_data$token == "expr", ]
+          if (nrow(top_level_exprs) >= ${i}) {
+            top_level_exprs$line2[${i}]
+          } else {
+            NA
+          }
+        }
+      `);
+
+      // Check if cursor is within this expression's range
+      if (cursorLine >= startLine && cursorLine <= endLine) {
+        return {
+          index: i,
+          lineStart: startLine,
+          lineEnd: endLine,
+        };
+      }
+    }
+
+    return null;
+  } catch (error) {
+    console.error('Error finding expression at line:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Execute R code at cursor position with Cmd+Enter (new default)
- Run all code with Cmd+Shift+Enter (was Cmd+Enter)
- Visual execution history tracking: dark blue left border for recently executed lines, light blue for previously executed
- Preserves cursor position when executing current expression
- Results merge intelligently with existing output

## Implementation

- **expression-finder.ts**: Parses R code to locate expression boundaries at cursor line
- **execution-gutter.ts**: Tracks execution history (recent vs previous) and renders line decorations
- **executeCurrentExpression()**: Executes single R expression and returns result with line range
- **Keyboard shortcuts**: Cmd+Enter (current expression), Cmd+Shift+Enter (all code)
- **Result merging**: Removes overlapping results, sorts by line number, updates line groups
- **Visual feedback**: Execution state propagates to spacers for consistent styling throughout editor

## Test plan

- [ ] Execute single expression with Cmd+Enter
- [ ] Verify cursor stays in place after execution
- [ ] Execute multiple expressions and verify history tracking
- [ ] Run all with Cmd+Shift+Enter and verify all lines marked as recent
- [ ] Check visual indicators (dark blue = recent, light blue = previous)