### PR TITLE
Implement partial line group update

### DIFF
--- a/plans/2025-011-partial-line-group-update.md
+++ b/plans/2025-011-partial-line-group-update.md
@@ -1,0 +1,13 @@
+# Partial line group update
+
+When doing a partial execution, we are currently replacing the entire
+set of line groups with a new set computed only from the results of
+the partial execution. This means that any line groups and results
+from prior executions are lost, even if they are still relevant/unchanged.
+
+## Solution
+
+Do a partial update of line groups. Logic is simple: any line groups
+not overlapping with the executed lines remain unchanged. Any line
+groups overlapping with executed lines are replaced with newly computed
+line groups from the partial execution.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,9 @@ function App() {
         const result = await executeScript(script, options);
         console.log("Execute result:", result);
 
-        const { lineGroups } = addResults(result.results);
+        const { lineGroups } = addResults(result.results, {
+          lineRange: options?.lineRange,
+        });
 
         editorRef.current?.applyExecutionUpdate({
           doc: script,

--- a/src/results.test.ts
+++ b/src/results.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import { processExecutionResults } from './results';
+import { ExecutionOutput } from './execution';
+import { LineGroup } from './compute-line-groups';
+
+describe('processExecutionResults', () => {
+  it('computes line groups from new results without options', () => {
+    const store = new Map<number, ExecutionOutput>();
+    const newResults: ExecutionOutput[] = [
+      { id: 1, lineStart: 1, lineEnd: 1, output: [] },
+      { id: 2, lineStart: 3, lineEnd: 3, output: [] },
+    ];
+
+    const { newStore, groups } = processExecutionResults(store, newResults);
+
+    expect(newStore.size).toBe(2);
+    expect(newStore.get(1)).toEqual(newResults[0]);
+    expect(newStore.get(2)).toEqual(newResults[1]);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].resultIds).toEqual([1]);
+    expect(groups[1].resultIds).toEqual([2]);
+  });
+
+  it('preserves non-overlapping groups during partial execution', () => {
+    const store = new Map<number, ExecutionOutput>();
+    store.set(1, { id: 1, lineStart: 1, lineEnd: 1, output: [] });
+    store.set(2, { id: 2, lineStart: 3, lineEnd: 3, output: [] });
+    store.set(3, { id: 3, lineStart: 5, lineEnd: 5, output: [] });
+
+    const currentLineGroups: LineGroup[] = [
+      { id: 'g1', resultIds: [1], lineStart: 1, lineEnd: 1 },
+      { id: 'g2', resultIds: [2], lineStart: 3, lineEnd: 3 },
+      { id: 'g3', resultIds: [3], lineStart: 5, lineEnd: 5 },
+    ];
+
+    const newResults: ExecutionOutput[] = [
+      { id: 4, lineStart: 3, lineEnd: 3, output: [] },
+    ];
+
+    const { newStore, groups } = processExecutionResults(store, newResults, {
+      currentLineGroups,
+      lineRange: { from: 3, to: 3 },
+    });
+
+    expect(newStore.size).toBe(4);
+    expect(groups).toHaveLength(3);
+    expect(groups[0].resultIds).toEqual([1]);
+    expect(groups[0].lineStart).toBe(1);
+    expect(groups[1].resultIds).toEqual([4]);
+    expect(groups[1].lineStart).toBe(3);
+    expect(groups[2].resultIds).toEqual([3]);
+    expect(groups[2].lineStart).toBe(5);
+  });
+
+  it('removes overlapping group when lineEnd < from', () => {
+    const store = new Map<number, ExecutionOutput>();
+    const currentLineGroups: LineGroup[] = [
+      { id: 'g1', resultIds: [1], lineStart: 1, lineEnd: 2 },
+      { id: 'g2', resultIds: [2], lineStart: 5, lineEnd: 6 },
+    ];
+
+    const newResults: ExecutionOutput[] = [
+      { id: 3, lineStart: 1, lineEnd: 1, output: [] },
+    ];
+
+    const { groups } = processExecutionResults(store, newResults, {
+      currentLineGroups,
+      lineRange: { from: 1, to: 2 },
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].resultIds).toEqual([3]);
+    expect(groups[0].lineStart).toBe(1);
+    expect(groups[1].resultIds).toEqual([2]);
+    expect(groups[1].lineStart).toBe(5);
+  });
+
+  it('removes overlapping group when lineStart > to', () => {
+    const store = new Map<number, ExecutionOutput>();
+    const currentLineGroups: LineGroup[] = [
+      { id: 'g1', resultIds: [1], lineStart: 1, lineEnd: 2 },
+      { id: 'g2', resultIds: [2], lineStart: 5, lineEnd: 6 },
+    ];
+
+    const newResults: ExecutionOutput[] = [
+      { id: 3, lineStart: 5, lineEnd: 5, output: [] },
+    ];
+
+    const { groups } = processExecutionResults(store, newResults, {
+      currentLineGroups,
+      lineRange: { from: 5, to: 6 },
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].resultIds).toEqual([1]);
+    expect(groups[0].lineStart).toBe(1);
+    expect(groups[1].resultIds).toEqual([3]);
+    expect(groups[1].lineStart).toBe(5);
+  });
+
+  it('removes multiple overlapping groups', () => {
+    const store = new Map<number, ExecutionOutput>();
+    const currentLineGroups: LineGroup[] = [
+      { id: 'g1', resultIds: [1], lineStart: 1, lineEnd: 2 },
+      { id: 'g2', resultIds: [2], lineStart: 3, lineEnd: 4 },
+      { id: 'g3', resultIds: [3], lineStart: 5, lineEnd: 6 },
+      { id: 'g4', resultIds: [4], lineStart: 10, lineEnd: 11 },
+    ];
+
+    const newResults: ExecutionOutput[] = [
+      { id: 5, lineStart: 3, lineEnd: 5, output: [] },
+    ];
+
+    const { groups } = processExecutionResults(store, newResults, {
+      currentLineGroups,
+      lineRange: { from: 3, to: 6 },
+    });
+
+    expect(groups).toHaveLength(3);
+    expect(groups[0].resultIds).toEqual([1]);
+    expect(groups[0].lineStart).toBe(1);
+    expect(groups[1].resultIds).toEqual([5]);
+    expect(groups[1].lineStart).toBe(3);
+    expect(groups[2].resultIds).toEqual([4]);
+    expect(groups[2].lineStart).toBe(10);
+  });
+
+  it('sorts merged groups by lineStart', () => {
+    const store = new Map<number, ExecutionOutput>();
+    const currentLineGroups: LineGroup[] = [
+      { id: 'g1', resultIds: [1], lineStart: 1, lineEnd: 2 },
+      { id: 'g2', resultIds: [2], lineStart: 10, lineEnd: 11 },
+    ];
+
+    const newResults: ExecutionOutput[] = [
+      { id: 3, lineStart: 5, lineEnd: 5, output: [] },
+    ];
+
+    const { groups } = processExecutionResults(store, newResults, {
+      currentLineGroups,
+      lineRange: { from: 5, to: 5 },
+    });
+
+    expect(groups).toHaveLength(3);
+    expect(groups[0].lineStart).toBe(1);
+    expect(groups[1].lineStart).toBe(5);
+    expect(groups[2].lineStart).toBe(10);
+  });
+
+  it('handles empty new results with partial execution', () => {
+    const store = new Map<number, ExecutionOutput>();
+    const currentLineGroups: LineGroup[] = [
+      { id: 'g1', resultIds: [1], lineStart: 1, lineEnd: 2 },
+      { id: 'g2', resultIds: [2], lineStart: 5, lineEnd: 6 },
+    ];
+
+    const newResults: ExecutionOutput[] = [];
+
+    const { groups } = processExecutionResults(store, newResults, {
+      currentLineGroups,
+      lineRange: { from: 3, to: 4 },
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].resultIds).toEqual([1]);
+    expect(groups[1].resultIds).toEqual([2]);
+  });
+
+  it('replaces all groups when lineRange covers everything', () => {
+    const store = new Map<number, ExecutionOutput>();
+    const currentLineGroups: LineGroup[] = [
+      { id: 'g1', resultIds: [1], lineStart: 2, lineEnd: 3 },
+      { id: 'g2', resultIds: [2], lineStart: 5, lineEnd: 6 },
+    ];
+
+    const newResults: ExecutionOutput[] = [
+      { id: 3, lineStart: 1, lineEnd: 1, output: [] },
+    ];
+
+    const { groups } = processExecutionResults(store, newResults, {
+      currentLineGroups,
+      lineRange: { from: 1, to: 10 },
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].resultIds).toEqual([3]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the issue where partial execution (Cmd+Enter on a single line) would clear all previously executed results. Now preserves line groups that don't overlap with the executed range.

**Before:** Executing line 3 would remove results from lines 1, 2, 4, etc.  
**After:** Executing line 3 only updates line 3's results, keeping all others intact.

## Changes

- Updated `processExecutionResults()` in `src/results.ts` to accept `lineRange` and `currentLineGroups` parameters
- Implemented overlap detection logic: `group.lineEnd < from || group.lineStart > to`
- Non-overlapping groups are preserved, overlapping groups are replaced
- Threaded `lineRange` through `App.tsx` execution flow to the results hook
- Added comprehensive test suite with 8 test cases covering edge cases
- Included plan document `plans/2025-011-partial-line-group-update.md`

## Test plan

- [x] Run all existing tests (36 tests pass)
- [x] Test with Chrome MCP: execute full script, then partial execution on single line
- [x] Verify non-overlapping groups preserved
- [x] Verify overlapping groups replaced correctly
- [x] Test multiple partial executions in sequence