### PR TITLE
Add rdit skill for Claude Code collaboration

### DIFF
--- a/.claude/skills/rdit/SKILL.md
+++ b/.claude/skills/rdit/SKILL.md
@@ -16,14 +16,14 @@ rdit runs from the local uv environment so dependencies work seamlessly.
 
 If pyproject.toml exists, just add rdit and run:
 ```bash
-uv add git+https://github.com/vangberg/rdit@file-watcher
+uv add git+ssh://git@github.com/vangberg/rdit@file-watcher
 uv run rdit script.py
 ```
 
 If starting fresh:
 ```bash
 uv init
-uv add git+https://github.com/vangberg/rdit@file-watcher
+uv add git+ssh://git@github.com/vangberg/rdit@file-watcher
 uv run rdit script.py
 ```
 

--- a/.claude/skills/rdit/SKILL.md
+++ b/.claude/skills/rdit/SKILL.md
@@ -72,10 +72,16 @@ def load_and_analyze(path):
 **File watching enabled** (`file-watcher` branch): When you edit the Python file, changes appear
 in the user's editor automatically.
 
+**Validate before the user sees it:**
+- Run the script yourself with `uv run script.py` before presenting to user
+- Fix any errors or warnings so output is clean
+- User should see working code, not debug your mistakes
+
 **Recommended workflow:**
-1. Edit the `.py` file directly - user sees changes immediately
-2. User runs code with Cmd+Enter to test
-3. Iterate based on results user describes
+1. Write/edit the `.py` file
+2. Run `uv run script.py` to validate - fix any errors
+3. User sees clean code and runs with Cmd+Enter
+4. Iterate based on results user describes
 
 **When user shares output:**
 - Results show stdout, stderr, and expression values

--- a/.claude/skills/rdit/SKILL.md
+++ b/.claude/skills/rdit/SKILL.md
@@ -44,7 +44,10 @@ Server runs on `127.0.0.1:8888`, browser opens automatically.
 - Focus on data exploration: load, inspect, transform, visualize
 
 ```python
-# Good - exploratory, each line shows a result
+# /// script
+# dependencies = ["pandas"]
+# ///
+
 import pandas as pd
 
 df = pd.read_csv("data.csv")
@@ -53,11 +56,6 @@ df.shape
 df.describe()
 df["price"].mean()
 df[df["price"] > 100]
-
-# Avoid - over-engineered for exploration
-def load_and_analyze(path):
-    df = pd.read_csv(path)
-    return df.describe()
 ```
 
 ## Execution Model
@@ -107,14 +105,18 @@ GET  /api/health          - Health check
 
 ## Dependencies
 
-rdit runs in its own isolated uvx environment. If the script needs packages beyond the standard library, include them with `--with` when starting rdit:
+Use PEP 723 inline script metadata at the top of the script. `uv run` auto-installs them - no server restart needed:
 
-```bash
-# Single dependency
-uvx --from git+ssh://git@github.com/vangberg/rdit@file-watcher --with pandas rdit script.py
+```python
+# /// script
+# dependencies = ["pandas", "google-cloud-bigquery"]
+# ///
 
-# Multiple dependencies
-uvx --from git+ssh://git@github.com/vangberg/rdit@file-watcher --with pandas --with google-cloud-bigquery rdit script.py
+import pandas as pd
+from google.cloud import bigquery
+
+df = pd.read_csv("data.csv")
+df.head()
 ```
 
-If you see `ModuleNotFoundError` in rdit, restart it with the missing package added via `--with`.
+When validating with `uv run script.py`, dependencies install automatically.

--- a/.claude/skills/rdit/SKILL.md
+++ b/.claude/skills/rdit/SKILL.md
@@ -12,11 +12,22 @@ split-pane interface: code editor (left) and streaming execution results (right)
 
 **Starting rdit:**
 
-Run as a background job so you can continue editing the file:
+rdit runs from the local uv environment so dependencies work seamlessly.
+
+If pyproject.toml exists, just add rdit and run:
 ```bash
-uvx --from git+https://github.com/vangberg/rdit@file-watcher rdit script.py
+uv add git+https://github.com/vangberg/rdit@file-watcher
+uv run rdit script.py
 ```
-Use `run_in_background: true` in the Bash tool.
+
+If starting fresh:
+```bash
+uv init
+uv add git+https://github.com/vangberg/rdit@file-watcher
+uv run rdit script.py
+```
+
+Run with `run_in_background: true` in the Bash tool so you can continue editing.
 
 Options: `--port 9000` (different port), `--no-browser` (don't auto-open browser)
 
@@ -44,10 +55,6 @@ Server runs on `127.0.0.1:8888`, browser opens automatically.
 - Focus on data exploration: load, inspect, transform, visualize
 
 ```python
-# /// script
-# dependencies = ["pandas"]
-# ///
-
 import pandas as pd
 
 df = pd.read_csv("data.csv")
@@ -105,18 +112,10 @@ GET  /api/health          - Health check
 
 ## Dependencies
 
-Use PEP 723 inline script metadata at the top of the script. `uv run` auto-installs them - no server restart needed:
+Since rdit runs from the local uv environment, add packages with `uv add`:
 
-```python
-# /// script
-# dependencies = ["pandas", "google-cloud-bigquery"]
-# ///
-
-import pandas as pd
-from google.cloud import bigquery
-
-df = pd.read_csv("data.csv")
-df.head()
+```bash
+uv add pandas matplotlib
 ```
 
-When validating with `uv run script.py`, dependencies install automatically.
+No server restart needed - packages are available immediately in both rdit and `uv run` validation.

--- a/.claude/skills/rdit/SKILL.md
+++ b/.claude/skills/rdit/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: rdit
+description: |
+  Collaborate with users running rdit - an interactive Python editor with inline execution results.
+  Use when: (1) User mentions rdit or is running `rdit` command, (2) User is editing Python with
+  inline/streaming results visible, (3) Collaborative Python development where user sees live
+  execution output, (4) User mentions "uvx rdit" or similar commands.
+---
+
+# rdit Collaboration
+
+rdit is an interactive Python editor with inline execution results. The user sees a browser-based
+split-pane interface: code editor (left) and streaming execution results (right).
+
+## User's Environment
+
+**Starting rdit:**
+
+Run as a background job so you can continue editing the file:
+```bash
+uvx --from git+https://github.com/vangberg/rdit@file-watcher rdit script.py
+```
+Use `run_in_background: true` in the Bash tool.
+
+Options: `--port 9000` (different port), `--no-browser` (don't auto-open browser)
+
+Server runs on `127.0.0.1:8888`, browser opens automatically.
+
+**What the user sees:**
+- Left pane: CodeMirror Python editor with syntax highlighting
+- Right pane: Execution results grouped by source lines
+- Top bar: RUN CURRENT, RUN ALL, SAVE buttons
+
+**User shortcuts:**
+| Action | Mac | Windows/Linux |
+|--------|-----|---------------|
+| Execute selection/current | Cmd+Enter | Ctrl+Enter |
+| Execute all | Cmd+Shift+Enter | Ctrl+Shift+Enter |
+| Save | Cmd+S | Ctrl+S |
+
+## Code Style
+
+**Write simple, top-level exploratory code** - like a Jupyter notebook, not a production module.
+
+- Prefer flat, sequential statements over functions and classes
+- Each line/expression shows its result inline - take advantage of this
+- Avoid unnecessary abstractions, loops, or defensive code
+- Focus on data exploration: load, inspect, transform, visualize
+
+```python
+# Good - exploratory, each line shows a result
+import pandas as pd
+
+df = pd.read_csv("data.csv")
+df.head()
+df.shape
+df.describe()
+df["price"].mean()
+df[df["price"] > 100]
+
+# Avoid - over-engineered for exploration
+def load_and_analyze(path):
+    df = pd.read_csv(path)
+    return df.describe()
+```
+
+## Execution Model
+
+- **Stateful**: Variables persist across executions (like Jupyter kernel)
+- **Streaming**: Results appear as each statement completes via SSE
+- **Line-grouped**: Results display next to the code that produced them
+- **Reset**: User can reset namespace to clear all variables
+
+## Collaboration Workflow
+
+**File watching enabled** (`file-watcher` branch): When you edit the Python file, changes appear
+in the user's editor automatically.
+
+**Recommended workflow:**
+1. Edit the `.py` file directly - user sees changes immediately
+2. User runs code with Cmd+Enter to test
+3. Iterate based on results user describes
+
+**When user shares output:**
+- Results show stdout, stderr, and expression values
+- Errors include full tracebacks
+- Results are associated with specific line ranges
+
+## API (if needed)
+
+```
+POST /api/execute-script  - Execute code (SSE streaming)
+POST /api/reset           - Reset namespace
+GET  /api/read-file       - Read file from disk
+POST /api/save-file       - Save file to disk
+GET  /api/health          - Health check
+```
+
+## Tips
+
+- Expressions show their values inline - `print()` is rarely needed
+- Write intermediate expressions to see values: `df.shape` instead of `print(df.shape)`
+- Long-running code streams results as each statement completes
+- User has full filesystem and package access (local Python execution)

--- a/.claude/skills/rdit/SKILL.md
+++ b/.claude/skills/rdit/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: rdit
-description: |
-  Collaborate with users running rdit - an interactive Python editor with inline execution results.
-  Use when: (1) User mentions rdit or is running `rdit` command, (2) User is editing Python with
-  inline/streaming results visible, (3) Collaborative Python development where user sees live
-  execution output, (4) User mentions "uvx rdit" or similar commands.
+description: Collaborate with users running rdit, an interactive Python editor with inline execution results. Use when user mentions rdit, runs uvx rdit, or is doing collaborative Python development where they see live execution output in a browser.
 ---
 
 # rdit Collaboration

--- a/.claude/skills/rdit/SKILL.md
+++ b/.claude/skills/rdit/SKILL.md
@@ -104,3 +104,17 @@ GET  /api/health          - Health check
 - Write intermediate expressions to see values: `df.shape` instead of `print(df.shape)`
 - Long-running code streams results as each statement completes
 - User has full filesystem and package access (local Python execution)
+
+## Dependencies
+
+rdit runs in its own isolated uvx environment. If the script needs packages beyond the standard library, include them with `--with` when starting rdit:
+
+```bash
+# Single dependency
+uvx --from git+ssh://git@github.com/vangberg/rdit@file-watcher --with pandas rdit script.py
+
+# Multiple dependencies
+uvx --from git+ssh://git@github.com/vangberg/rdit@file-watcher --with pandas --with google-cloud-bigquery rdit script.py
+```
+
+If you see `ModuleNotFoundError` in rdit, restart it with the missing package added via `--with`.


### PR DESCRIPTION
## Summary

- Adds a Claude Code skill at `.claude/skills/rdit/SKILL.md`
- Helps Claude collaborate with users running rdit interactively
- Covers: starting server as background job, writing exploratory code, stateful execution, file watching

## Test plan

- [ ] Install skill from branch: copy `.claude/skills/rdit/` to `~/.claude/skills/`
- [ ] Start new Claude Code session and mention rdit to trigger skill
- [ ] Verify Claude understands how to start rdit and write appropriate exploratory code

🤖 Generated with [Claude Code](https://claude.com/claude-code)