### PR TITLE
Add matplotlib plot capture support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
     "ruff>=0.1.0",
     "pandas>=2.0.0",
     "polars>=0.19.0",
-    "matplotlib>=3.5.0",
 ]
 
 [project.urls]
@@ -81,3 +80,9 @@ python_version = "3.8"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
+
+[dependency-groups]
+dev = [
+    "matplotlib>=3.7.5",
+    "polars>=1.8.2",
+]

--- a/sample.py
+++ b/sample.py
@@ -1,7 +1,35 @@
 import polars as pl
+import matplotlib.pyplot as plt
 
 # Load iris dataset (150 rows) and repeat to get ~500 rows
 df = pl.read_csv("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/iris.csv")
 df = pl.concat([df] * 4)  # Repeat 4 times for 600 rows
 
 df
+
+# Create a matplotlib scatter plot of the iris data
+fig, ax = plt.subplots()
+
+# Get unique species for coloring
+species_list = df["species"].unique().to_list()
+colors = ['red', 'green', 'blue']
+
+for species, color in zip(species_list, colors):
+    species_data = df.filter(pl.col("species") == species)
+    ax.scatter(
+        species_data["sepal_length"],
+        species_data["sepal_width"],
+        c=color,
+        label=species,
+        alpha=0.6
+    )
+
+ax.set_xlabel("Sepal Length (cm)")
+ax.set_ylabel("Sepal Width (cm)")
+ax.set_title("Iris Dataset: Sepal Length vs Sepal Width")
+ax.legend()
+ax.grid(True, alpha=0.3)
+
+fig
+
+

--- a/uv.lock
+++ b/uv.lock
@@ -2943,9 +2943,6 @@ dependencies = [
 dev = [
     { name = "black", version = "24.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "black", version = "25.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "matplotlib", version = "3.7.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "matplotlib", version = "3.10.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "mypy", version = "1.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "mypy", version = "1.18.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pandas", version = "2.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -2961,13 +2958,21 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "matplotlib", version = "3.7.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "matplotlib", version = "3.10.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "polars", version = "1.8.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "polars", version = "1.35.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=23.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "fastapi", specifier = ">=0.104.0" },
-    { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "polars", marker = "extra == 'dev'", specifier = ">=0.19.0" },
@@ -2978,6 +2983,12 @@ requires-dist = [
     { name = "watchfiles", specifier = ">=0.20.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "matplotlib", specifier = ">=3.7.5" },
+    { name = "polars", specifier = ">=1.8.2" },
+]
 
 [[package]]
 name = "ruff"


### PR DESCRIPTION
## Summary

- Implement matplotlib plot capture functionality in rdit
- Add automatic Agg backend setup to prevent segfaults
- Refactor image output to use ImageBitmap for proper rendering
- Fix split-container height calculation to account for top bar

## Changes

- **Backend setup**: Automatically set matplotlib Agg backend on executor initialization to prevent display/segfault issues
- **Plot capture**: Add detection and capture for matplotlib Axes and Figure objects returned from expressions
- **Image rendering**: Refactor ImageOutput component to properly store and redraw ImageBitmap when dimensions change
- **Layout fix**: Change split-container from `min-height: 100%` to `flex: 1` to properly fill space after top bar
- **Sample**: Add matplotlib scatter plot example to sample.py
- **Tests**: Comprehensive test suite for matplotlib capture functionality

## Test plan

- [x] Run existing tests
- [x] Test matplotlib plot capture in browser
- [x] Verify Agg backend prevents segfaults
- [x] Verify split-container layout fix
- [x] Test with sample.py matplotlib example