### PR TITLE
Add keyboard shortcuts for Reader and Autorun

### DIFF
--- a/web/src/Script.tsx
+++ b/web/src/Script.tsx
@@ -258,14 +258,25 @@ export function Script({ scriptPath, onPathChange }: ScriptProps) {
     }
   }, [scriptPath, doc, handleExecute]);
 
-  // Handle Cmd+S / Ctrl+S keyboard shortcut
+  // Handle keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      // Cmd+S / Ctrl+S - Save
       if ((e.metaKey || e.ctrlKey) && e.key === "s") {
         e.preventDefault();
         if (hasUnsavedChanges) {
           handleSave();
         }
+      }
+      // Cmd+\ / Ctrl+\ - Toggle Reader mode
+      if ((e.metaKey || e.ctrlKey) && e.key === "\\") {
+        e.preventDefault();
+        setReaderMode((prev) => !prev);
+      }
+      // Cmd+Shift+A / Ctrl+Shift+A - Toggle Autorun
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "A") {
+        e.preventDefault();
+        setAutorun((prev) => !prev);
       }
     };
 

--- a/web/src/TopBar.tsx
+++ b/web/src/TopBar.tsx
@@ -26,6 +26,8 @@ function getShortcuts() {
   return {
     current: isMac ? "Command + Enter" : "Ctrl + Enter",
     all: isMac ? "Command + Shift + Enter" : "Ctrl + Shift + Enter",
+    reader: isMac ? "Command + \\" : "Ctrl + \\",
+    autorun: isMac ? "Command + Shift + A" : "Ctrl + Shift + A",
   };
 }
 
@@ -180,7 +182,7 @@ export function TopBar({
           enabled={readerMode ?? false}
           onToggle={onToggleReaderMode || (() => {})}
           label="READER"
-          tooltip="Toggle reader mode"
+          tooltip={shortcuts.reader}
           showTooltip={hoveredButton === "reader"}
           onMouseEnter={() => setHoveredButton("reader")}
           onMouseLeave={() => setHoveredButton(null)}
@@ -191,7 +193,7 @@ export function TopBar({
             enabled={autorun ?? false}
             onToggle={onAutorunToggle}
             label="AUTORUN"
-            tooltip="Auto-execute script on save or file change"
+            tooltip={shortcuts.autorun}
             showTooltip={hoveredButton === "autorun"}
             onMouseEnter={() => setHoveredButton("autorun")}
             onMouseLeave={() => setHoveredButton(null)}


### PR DESCRIPTION
## Summary
- **Cmd+\\** (Ctrl+\\) toggles Reader mode
- **Cmd+Shift+A** (Ctrl+Shift+A) toggles Autorun
- Tooltips show keyboard shortcuts on hover (matching other TopBar buttons)

## Test plan
- [ ] Cmd+\ toggles Reader mode on/off
- [ ] Cmd+Shift+A toggles Autorun on/off
- [ ] Hover over Reader/Autorun buttons shows shortcut tooltip