### PR TITLE
feat: persist autorun and reader settings per script

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,11 +4,10 @@ import "./style.css";
 
 function App() {
   // Parse URL params once on mount
-  const [{ scriptPath: initialScriptPath, autorun: initialAutorun }] = useState(() => {
+  const [{ scriptPath: initialScriptPath }] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     return {
       scriptPath: params.get("script"),
-      autorun: params.has("autorun"),
     };
   });
   const [scriptPath, setScriptPath] = useState(initialScriptPath);
@@ -34,7 +33,13 @@ function App() {
     setScriptPath(newPath || null);
   }, []);
 
-  return <Script scriptPath={scriptPath} onPathChange={handlePathChange} initialAutorun={initialAutorun} />;
+  return (
+    <Script
+      key={scriptPath || "no-script"}
+      scriptPath={scriptPath}
+      onPathChange={handlePathChange}
+    />
+  );
 }
 
 export default App;

--- a/web/src/Script.tsx
+++ b/web/src/Script.tsx
@@ -10,21 +10,22 @@ import { TopBar } from "./TopBar";
 import { useResults } from "./results";
 import { useScriptFile } from "./use-script-file";
 import { LineGroupLayout } from "./line-group-layout";
+import { useScriptSettings } from "./use-script-settings";
 
 const DEFAULT_CODE = ``;
 
 interface ScriptProps {
   scriptPath: string | null;
   onPathChange?: (newPath: string) => void;
-  initialAutorun?: boolean;
 }
 
-export function Script({ scriptPath, onPathChange, initialAutorun }: ScriptProps) {
+export function Script({ scriptPath, onPathChange }: ScriptProps) {
   const [hasConflict, setHasConflict] = useState(false);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [doc, setDoc] = useState<Text>();
-  const [readerMode, setReaderMode] = useState(false);
-  const [autorun, setAutorun] = useState(initialAutorun ?? false);
+  
+  const { autorun, setAutorun, readerMode, setReaderMode } = useScriptSettings(scriptPath);
+
   const [isFuzzyFinderOpen, setIsFuzzyFinderOpen] = useState(false);
   const autorunRef = useRef(false);
   const isProgrammaticUpdate = useRef(false);
@@ -239,8 +240,8 @@ export function Script({ scriptPath, onPathChange, initialAutorun }: ScriptProps
   }, []);
 
   const handleToggleReaderMode = useCallback(() => {
-    setReaderMode((prev) => !prev);
-  }, []);
+    setReaderMode(!readerMode);
+  }, [readerMode, setReaderMode]);
 
   const handleSave = useCallback(async () => {
     if (!scriptPath || !doc) {

--- a/web/src/use-script-settings.ts
+++ b/web/src/use-script-settings.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, useCallback } from "react";
+
+const STORAGE_PREFIX = "pdit-settings-";
+
+interface ScriptSettings {
+  autorun: boolean;
+  readerMode: boolean;
+}
+
+const DEFAULT_SETTINGS: ScriptSettings = {
+  autorun: false,
+  readerMode: false,
+};
+
+export function useScriptSettings(scriptPath: string | null) {
+  const getStoredSettings = useCallback((): ScriptSettings => {
+    if (!scriptPath) return DEFAULT_SETTINGS;
+    try {
+      const item = localStorage.getItem(`${STORAGE_PREFIX}${scriptPath}`);
+      return item ? { ...DEFAULT_SETTINGS, ...JSON.parse(item) } : DEFAULT_SETTINGS;
+    } catch {
+      return DEFAULT_SETTINGS;
+    }
+  }, [scriptPath]);
+
+  const [settings, setSettings] = useState<ScriptSettings>(getStoredSettings);
+
+  useEffect(() => {
+    setSettings(getStoredSettings());
+  }, [getStoredSettings]);
+
+  const updateSettings = useCallback((newPartialSettings: Partial<ScriptSettings>) => {
+    setSettings((prev) => {
+      const updated = { ...prev, ...newPartialSettings };
+      if (scriptPath) {
+        try {
+          localStorage.setItem(`${STORAGE_PREFIX}${scriptPath}`, JSON.stringify(updated));
+        } catch (e) {
+          console.warn("Failed to save settings", e);
+        }
+      }
+      return updated;
+    });
+  }, [scriptPath]);
+
+  return {
+    autorun: settings.autorun,
+    setAutorun: (val: boolean) => updateSettings({ autorun: val }),
+    readerMode: settings.readerMode,
+    setReaderMode: (val: boolean) => updateSettings({ readerMode: val }),
+  };
+}


### PR DESCRIPTION
Removes the URL-based autorun functionality and replaces it with a local storage-based persistence for 'autorun' and 'reader mode' settings, keyed by the script path. This ensures that user preferences for these modes are remembered for each specific script.