### PR TITLE
Add token-based authentication

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
-.PHONY: dev 
+.PHONY: dev
 
 dev:
-	@echo "Starting pdit backend and frontend dev servers..."
-	@trap 'kill 0' EXIT; \
-	uv run pdit --no-browser --port 8888 & \
-	cd web && npm run dev
+	@echo "Building frontend and starting pdit..."
+	cd web && npm run build
+	uv run pdit --port 8888

--- a/TINYTODO.md
+++ b/TINYTODO.md
@@ -20,3 +20,4 @@ When a todo is done, delete it.
 6. Text-wrap output, even when there's no whitespace.
 7. `"""` should trigger `"""\n[CURSOR]\n"""`
 8. Disable CodeMirror code folding
+* Autorun after reload from disk (if enabled!)

--- a/pdit/cli.py
+++ b/pdit/cli.py
@@ -14,6 +14,7 @@ import threading
 import webbrowser
 from pathlib import Path
 from typing import Optional
+from urllib.parse import urlencode
 
 import typer
 from typing_extensions import Annotated
@@ -129,16 +130,16 @@ def start(
     # Generate secure token for this server instance (unless disabled)
     auth_token = None if disable_token_auth else secrets.token_urlsafe(32)
 
-    # Build URL with token (if enabled)
+    # Build URL with properly encoded query parameters
+    params = {}
     if script_path:
-        url = f"http://{host}:{actual_port}?script={script_path}"
-        if auth_token:
-            url += f"&token={auth_token}"
-    else:
-        if auth_token:
-            url = f"http://{host}:{actual_port}?token={auth_token}"
-        else:
-            url = f"http://{host}:{actual_port}"
+        params["script"] = script_path
+    if auth_token:
+        params["token"] = auth_token
+
+    url = f"http://{host}:{actual_port}"
+    if params:
+        url += f"?{urlencode(params)}"
 
     # Pretty startup output
     typer.echo()

--- a/pdit/cli.py
+++ b/pdit/cli.py
@@ -5,6 +5,7 @@ Provides the `pdit` command to start the server and open the web interface.
 """
 
 import contextlib
+import secrets
 import signal
 import socket
 import sys
@@ -123,16 +124,21 @@ def start(
             typer.echo(f"Error: Port {port} is already in use", err=True)
             sys.exit(1)
 
-    # Build URL
-    url = f"http://{host}:{actual_port}"
+    # Generate secure token for this server instance
+    auth_token = secrets.token_urlsafe(32)
+
+    # Build URL with token
+    url = f"http://{host}:{actual_port}?token={auth_token}"
     if script_path:
-        url += f"?script={script_path}"
+        url += f"&script={script_path}"
 
     typer.echo(f"Starting pdit server on {host}:{actual_port}")
+    typer.echo(f"Access URL: {url}")
 
-    # Pass port to server via environment variable for CORS configuration
+    # Pass port and token to server via environment variables
     import os
     os.environ["PDIT_PORT"] = str(actual_port)
+    os.environ["PDIT_AUTH_TOKEN"] = auth_token
 
     # Configure and create server
     config = uvicorn.Config(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,17 +12,15 @@ function AppContent() {
     setAuthErrorCallback(setAuthError);
   }, [setAuthError]);
 
-  // Extract and store auth token from URL
-  useEffect(() => {
+  // Extract and store auth token from URL BEFORE first render
+  // This must happen synchronously so API calls have the token available
+  const [{ scriptPath: initialScriptPath }] = useState(() => {
     const hasToken = extractAndStoreToken();
     if (hasToken) {
       // Remove token from URL for security (it's now in localStorage)
       removeTokenFromUrl();
     }
-  }, []);
 
-  // Parse URL params once on mount
-  const [{ scriptPath: initialScriptPath }] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     return {
       scriptPath: params.get("script"),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,8 +1,26 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { Script } from "./Script";
+import { extractAndStoreToken, removeTokenFromUrl, setAuthErrorCallback } from "./auth";
+import { AuthErrorProvider, useAuthError } from "./auth-error-context";
 import "./style.css";
 
-function App() {
+function AppContent() {
+  const { hasAuthError, setAuthError } = useAuthError();
+
+  // Register auth error callback
+  useEffect(() => {
+    setAuthErrorCallback(setAuthError);
+  }, [setAuthError]);
+
+  // Extract and store auth token from URL
+  useEffect(() => {
+    const hasToken = extractAndStoreToken();
+    if (hasToken) {
+      // Remove token from URL for security (it's now in localStorage)
+      removeTokenFromUrl();
+    }
+  }, []);
+
   // Parse URL params once on mount
   const [{ scriptPath: initialScriptPath }] = useState(() => {
     const params = new URLSearchParams(window.location.search);
@@ -38,7 +56,16 @@ function App() {
       key={scriptPath || "no-script"}
       scriptPath={scriptPath}
       onPathChange={handlePathChange}
+      hasAuthError={hasAuthError}
     />
+  );
+}
+
+function App() {
+  return (
+    <AuthErrorProvider>
+      <AppContent />
+    </AuthErrorProvider>
   );
 }
 

--- a/web/src/Editor.tsx
+++ b/web/src/Editor.tsx
@@ -150,6 +150,10 @@ export function Editor({
           {
             key: "Cmd-Enter",
             run: (view: EditorView) => {
+              // Don't execute if editor is read-only (e.g., auth error)
+              if (view.state.readOnly) {
+                return false;
+              }
               executeCurrentSelection(view);
               return true;
             },
@@ -157,6 +161,10 @@ export function Editor({
           {
             key: "Cmd-Shift-Enter",
             run: (view: EditorView) => {
+              // Don't execute if editor is read-only (e.g., auth error)
+              if (view.state.readOnly) {
+                return false;
+              }
               const currentText = view.state.doc.toString();
               onExecuteAllRef.current?.(currentText);
               return true;

--- a/web/src/FuzzyFinder.tsx
+++ b/web/src/FuzzyFinder.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
+import { getAuthToken, triggerAuthError } from "./auth";
 
 interface FuzzyFinderProps {
   isOpen: boolean;
@@ -85,8 +86,21 @@ export function FuzzyFinder({ isOpen, onClose, onSelect }: FuzzyFinderProps) {
   useEffect(() => {
     if (isOpen) {
       setIsLoading(true);
-      fetch("/api/list-files")
-        .then((res) => res.json())
+
+      const token = getAuthToken();
+      const headers: Record<string, string> = {};
+
+      if (token) {
+        headers["X-Auth-Token"] = token;
+      }
+
+      fetch("/api/list-files", { headers })
+        .then((res) => {
+          if (!res.ok && res.status === 401) {
+            triggerAuthError();
+          }
+          return res.json();
+        })
         .then((data) => {
           setFiles(data.files);
           setIsLoading(false);

--- a/web/src/FuzzyFinder.tsx
+++ b/web/src/FuzzyFinder.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { getAuthToken, triggerAuthError } from "./auth";
+import * as apiClient from "./api-client";
 
 interface FuzzyFinderProps {
   isOpen: boolean;
@@ -87,20 +87,8 @@ export function FuzzyFinder({ isOpen, onClose, onSelect }: FuzzyFinderProps) {
     if (isOpen) {
       setIsLoading(true);
 
-      const token = getAuthToken();
-      const headers: Record<string, string> = {};
-
-      if (token) {
-        headers["X-Auth-Token"] = token;
-      }
-
-      fetch("/api/list-files", { headers })
-        .then((res) => {
-          if (!res.ok && res.status === 401) {
-            triggerAuthError();
-          }
-          return res.json();
-        })
+      apiClient
+        .listFiles()
         .then((data) => {
           setFiles(data.files);
           setIsLoading(false);

--- a/web/src/Script.tsx
+++ b/web/src/Script.tsx
@@ -11,7 +11,7 @@ import { useResults } from "./results";
 import { useScriptFile } from "./use-script-file";
 import { LineGroupLayout } from "./line-group-layout";
 import { useScriptSettings } from "./use-script-settings";
-import { getAuthToken, triggerAuthError } from "./auth";
+import * as apiClient from "./api-client";
 
 const DEFAULT_CODE = ``;
 
@@ -264,23 +264,7 @@ export function Script({ scriptPath, onPathChange, hasAuthError }: ScriptProps) 
     }
 
     try {
-      const token = getAuthToken();
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-      };
-
-      if (token) {
-        headers["X-Auth-Token"] = token;
-      }
-
-      const response = await fetch("/api/save-file", {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          path: scriptPath,
-          content: doc.toString(),
-        }),
-      });
+      const response = await apiClient.saveFile(scriptPath, doc.toString());
 
       if (response.ok) {
         setHasUnsavedChanges(false);
@@ -291,9 +275,6 @@ export function Script({ scriptPath, onPathChange, hasAuthError }: ScriptProps) 
           handleExecute(doc.toString());
         }
       } else {
-        if (response.status === 401) {
-          triggerAuthError();
-        }
         console.error("Failed to save file:", await response.text());
       }
     } catch (error) {

--- a/web/src/TopBar.tsx
+++ b/web/src/TopBar.tsx
@@ -20,6 +20,7 @@ interface TopBarProps {
   isFuzzyFinderOpen?: boolean;
   onFuzzyFinderOpenChange?: (open: boolean) => void;
   isExecuting?: boolean;
+  hasAuthError?: boolean;
 }
 
 function detectMacOS(): boolean {
@@ -87,6 +88,7 @@ interface ToggleSwitchProps {
   showTooltip: boolean;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
+  disabled?: boolean;
 }
 
 function ToggleSwitch({
@@ -96,7 +98,8 @@ function ToggleSwitch({
   tooltip,
   showTooltip,
   onMouseEnter,
-  onMouseLeave
+  onMouseLeave,
+  disabled
 }: ToggleSwitchProps) {
   return (
     <div
@@ -106,9 +109,10 @@ function ToggleSwitch({
     >
       <button
         className={`top-bar-toggle ${enabled ? "enabled" : ""}`}
-        onClick={() => onToggle(!enabled)}
+        onClick={() => !disabled && onToggle(!enabled)}
         role="switch"
         aria-checked={enabled}
+        disabled={disabled}
       >
         <span className="top-bar-toggle-label">{label}</span>
         <span className="top-bar-toggle-switch">
@@ -138,7 +142,8 @@ export function TopBar({
   onDebugModeToggle,
   isFuzzyFinderOpen,
   onFuzzyFinderOpenChange,
-  isExecuting
+  isExecuting,
+  hasAuthError
 }: TopBarProps) {
   const [hoveredButton, setHoveredButton] = useState<string | null>(null);
 
@@ -152,7 +157,7 @@ export function TopBar({
         <ActionButton
           label="▶ RUN CURRENT"
           onClick={onRunCurrent || (() => {})}
-          disabled={isExecuting || false}
+          disabled={isExecuting || hasAuthError || false}
           onMouseEnter={() => setHoveredButton("current")}
           onMouseLeave={() => setHoveredButton(null)}
           tooltip={shortcuts.current}
@@ -162,7 +167,7 @@ export function TopBar({
         <ActionButton
           label="▶ RUN ALL"
           onClick={onRunAll}
-          disabled={isExecuting || false}
+          disabled={isExecuting || hasAuthError || false}
           onMouseEnter={() => setHoveredButton("all")}
           onMouseLeave={() => setHoveredButton(null)}
           tooltip={shortcuts.all}
@@ -177,6 +182,7 @@ export function TopBar({
           showTooltip={hoveredButton === "reader"}
           onMouseEnter={() => setHoveredButton("reader")}
           onMouseLeave={() => setHoveredButton(null)}
+          disabled={hasAuthError}
         />
 
         {onAutorunToggle && (
@@ -188,6 +194,7 @@ export function TopBar({
             showTooltip={hoveredButton === "autorun"}
             onMouseEnter={() => setHoveredButton("autorun")}
             onMouseLeave={() => setHoveredButton(null)}
+            disabled={hasAuthError}
           />
         )}
 
@@ -200,6 +207,7 @@ export function TopBar({
             showTooltip={hoveredButton === "debug"}
             onMouseEnter={() => setHoveredButton("debug")}
             onMouseLeave={() => setHoveredButton(null)}
+            disabled={hasAuthError}
           />
         )}
 
@@ -207,7 +215,7 @@ export function TopBar({
           <ActionButton
             label="SAVE"
             onClick={onSave || (() => {})}
-            disabled={!(hasUnsavedChanges ?? false)}
+            disabled={!(hasUnsavedChanges ?? false) || hasAuthError || false}
             onMouseEnter={() => setHoveredButton("save")}
             onMouseLeave={() => setHoveredButton(null)}
             tooltip={saveShortcut}
@@ -252,6 +260,19 @@ export function TopBar({
               Keep
               {hoveredButton === "keep" && <Tooltip text="Keep your changes and dismiss this warning" />}
             </button>
+          </div>
+        )}
+
+        {hasAuthError && (
+          <div
+            className="top-bar-button-wrapper"
+            onMouseEnter={() => setHoveredButton("auth-error")}
+            onMouseLeave={() => setHoveredButton(null)}
+          >
+            <span className="top-bar-auth-error">⚠️ Auth failed</span>
+            {hoveredButton === "auth-error" && (
+              <Tooltip text="Copy the full URL from your terminal (including ?token=...) and paste it into your browser" />
+            )}
           </div>
         )}
       </div>

--- a/web/src/TopBar.tsx
+++ b/web/src/TopBar.tsx
@@ -114,7 +114,7 @@ function ToggleSwitch({
     >
       <button
         className={`top-bar-toggle ${enabled ? "enabled" : ""}`}
-        onClick={() => !disabled && onToggle(!enabled)}
+        onClick={() => onToggle(!enabled)}
         role="switch"
         aria-checked={enabled}
         disabled={disabled}

--- a/web/src/api-client.ts
+++ b/web/src/api-client.ts
@@ -1,0 +1,157 @@
+/**
+ * Centralized API client for all backend communication.
+ * Handles token authentication and error handling automatically.
+ */
+
+import { getAuthToken, triggerAuthError } from './auth';
+
+/**
+ * Create headers with auth token for fetch requests.
+ */
+function createHeaders(additionalHeaders: Record<string, string> = {}): Record<string, string> {
+  const token = getAuthToken();
+  const headers: Record<string, string> = { ...additionalHeaders };
+
+  if (token) {
+    headers['X-Auth-Token'] = token;
+  }
+
+  return headers;
+}
+
+/**
+ * Handle response errors, particularly 401 auth errors.
+ */
+function handleResponseError(response: Response): void {
+  if (response.status === 401) {
+    triggerAuthError();
+  }
+}
+
+/**
+ * Execute a Python script with SSE streaming.
+ */
+export async function executeScript(
+  script: string,
+  options: {
+    sessionId: string;
+    lineRange?: { from: number; to: number };
+    scriptName?: string;
+    reset?: boolean;
+  }
+): Promise<Response> {
+  const headers = createHeaders({
+    'Content-Type': 'application/json',
+    'Accept': 'text/event-stream',
+  });
+
+  const response = await fetch('/api/execute-script', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      script,
+      sessionId: options.sessionId,
+      scriptName: options.scriptName,
+      lineRange: options.lineRange,
+      reset: options.reset,
+    }),
+  });
+
+  if (!response.ok) {
+    handleResponseError(response);
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  return response;
+}
+
+/**
+ * Reset the execution namespace.
+ */
+export async function reset(): Promise<void> {
+  const headers = createHeaders();
+
+  const response = await fetch('/api/reset', {
+    method: 'POST',
+    headers,
+  });
+
+  if (!response.ok) {
+    handleResponseError(response);
+  }
+}
+
+/**
+ * Initialize a session to start kernel.
+ */
+export async function initSession(sessionId: string): Promise<Response> {
+  const headers = createHeaders({
+    'Content-Type': 'application/json',
+  });
+
+  const response = await fetch('/api/init-session', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ sessionId }),
+  });
+
+  if (!response.ok) {
+    handleResponseError(response);
+  }
+
+  return response;
+}
+
+/**
+ * Watch a file for changes via EventSource.
+ * Note: EventSource doesn't support custom headers, so token is passed as query param.
+ */
+export function watchFile(path: string, sessionId: string): EventSource {
+  const token = getAuthToken();
+  const url = new URL('/api/watch-file', window.location.origin);
+  url.searchParams.set('path', path);
+  url.searchParams.set('sessionId', sessionId);
+
+  if (token) {
+    url.searchParams.set('token', token);
+  }
+
+  return new EventSource(url.toString());
+}
+
+/**
+ * Save file content to disk.
+ */
+export async function saveFile(path: string, content: string): Promise<Response> {
+  const headers = createHeaders({
+    'Content-Type': 'application/json',
+  });
+
+  const response = await fetch('/api/save-file', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ path, content }),
+  });
+
+  if (!response.ok) {
+    handleResponseError(response);
+  }
+
+  return response;
+}
+
+/**
+ * List all Python files in current directory.
+ */
+export async function listFiles(): Promise<{ files: string[] }> {
+  const headers = createHeaders();
+
+  const response = await fetch('/api/list-files', { headers });
+
+  if (!response.ok) {
+    handleResponseError(response);
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  return response.json();
+}

--- a/web/src/api-client.ts
+++ b/web/src/api-client.ts
@@ -78,6 +78,7 @@ export async function reset(): Promise<void> {
 
   if (!response.ok) {
     handleResponseError(response);
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
   }
 }
 

--- a/web/src/auth-error-context.tsx
+++ b/web/src/auth-error-context.tsx
@@ -1,0 +1,35 @@
+/**
+ * Global context for authentication error state.
+ * Used to show auth errors from anywhere in the app.
+ */
+
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+interface AuthErrorContextType {
+  hasAuthError: boolean;
+  setAuthError: (error: boolean) => void;
+}
+
+const AuthErrorContext = createContext<AuthErrorContextType | undefined>(undefined);
+
+export function AuthErrorProvider({ children }: { children: React.ReactNode }) {
+  const [hasAuthError, setHasAuthError] = useState(false);
+
+  const setAuthError = useCallback((error: boolean) => {
+    setHasAuthError(error);
+  }, []);
+
+  return (
+    <AuthErrorContext.Provider value={{ hasAuthError, setAuthError }}>
+      {children}
+    </AuthErrorContext.Provider>
+  );
+}
+
+export function useAuthError() {
+  const context = useContext(AuthErrorContext);
+  if (!context) {
+    throw new Error('useAuthError must be used within AuthErrorProvider');
+  }
+  return context;
+}

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -1,0 +1,73 @@
+/**
+ * Authentication token management.
+ * Handles extracting token from URL, storing in localStorage, and providing it for API calls.
+ */
+
+const TOKEN_STORAGE_KEY = 'pdit_auth_token';
+
+// Global auth error callback - will be set by the app
+let authErrorCallback: ((hasError: boolean) => void) | null = null;
+
+/**
+ * Set the global auth error callback.
+ * This is called by the app to register the error handler.
+ */
+export function setAuthErrorCallback(callback: (hasError: boolean) => void): void {
+  authErrorCallback = callback;
+}
+
+/**
+ * Trigger auth error state.
+ * Called when a 401 response is received.
+ */
+export function triggerAuthError(): void {
+  if (authErrorCallback) {
+    authErrorCallback(true);
+  }
+}
+
+/**
+ * Get the auth token from localStorage.
+ */
+export function getAuthToken(): string | null {
+  return localStorage.getItem(TOKEN_STORAGE_KEY);
+}
+
+/**
+ * Store the auth token in localStorage.
+ */
+export function setAuthToken(token: string): void {
+  localStorage.setItem(TOKEN_STORAGE_KEY, token);
+}
+
+/**
+ * Remove the auth token from localStorage.
+ */
+export function clearAuthToken(): void {
+  localStorage.removeItem(TOKEN_STORAGE_KEY);
+}
+
+/**
+ * Extract token from URL parameters and store it.
+ * Returns true if token was found and stored.
+ */
+export function extractAndStoreToken(): boolean {
+  const params = new URLSearchParams(window.location.search);
+  const token = params.get('token');
+
+  if (token) {
+    setAuthToken(token);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Remove token from URL without navigation.
+ */
+export function removeTokenFromUrl(): void {
+  const url = new URL(window.location.href);
+  url.searchParams.delete('token');
+  window.history.replaceState({}, '', url);
+}

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -19,8 +19,10 @@ export function setAuthErrorCallback(callback: (hasError: boolean) => void): voi
 /**
  * Trigger auth error state.
  * Called when a 401 response is received.
+ * Clears the stale token so user can refresh with new URL.
  */
 export function triggerAuthError(): void {
+  clearAuthToken(); // Clear stale token from localStorage
   if (authErrorCallback) {
     authErrorCallback(true);
   }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -186,6 +186,21 @@ body {
   color: var(--bg-primary);
 }
 
+.top-bar-auth-error {
+  display: inline-flex;
+  align-items: center;
+  background: #dc2626;
+  border: 2px solid #991b1b;
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  color: #fff;
+  font-family: 'Fira Code', Monaco, Consolas, monospace;
+  white-space: nowrap;
+  font-weight: 600;
+}
+
 .top-bar-status-text {
   font-size: 0.75rem;
   text-transform: uppercase;
@@ -273,6 +288,18 @@ body {
 
 .top-bar-toggle.enabled .top-bar-toggle-knob {
   transform: translateX(12px);
+}
+
+.top-bar-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  border-color: #6b7280;
+  color: #6b7280;
+}
+
+.top-bar-toggle:disabled:hover {
+  background: transparent;
+  color: #6b7280;
 }
 
 .split-container {

--- a/web/src/use-script-file.ts
+++ b/web/src/use-script-file.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState, useRef, useMemo } from "react";
 import * as apiClient from "./api-client";
-import { triggerAuthError } from "./auth";
 
 interface UseScriptFileOptions {
   onFileChange?: (newContent: string) => void; // Callback when file changes (enables watching)
@@ -117,11 +116,9 @@ export function useScriptFile(
         // Close the connection to prevent automatic reconnection
         eventSource.close();
 
-        // EventSource doesn't expose status codes, but if we haven't
-        // received initial content yet, it's likely an auth error
+        // EventSource doesn't expose status codes, so we can't reliably
+        // distinguish auth errors from other failures (network issues, file not found, etc.)
         if (!hasReceivedInitialContent.current) {
-          // Could be 401 - trigger auth error as a precaution
-          triggerAuthError();
           setError(new Error("Failed to load file"));
           setIsLoading(false);
         } else {


### PR DESCRIPTION
## Summary

Implements secure token-based authentication for the pdit server to prevent unauthorized access to the local instance.

## How it works

**Backend:**
1. Server generates a unique 32-byte URL-safe token on startup using `secrets.token_urlsafe()`
2. Token is printed in the access URL: `http://127.0.0.1:8888?token=...`
3. Middleware validates token on all `/api/*` endpoints (except `/api/health`)
4. Accepts token via `X-Auth-Token` header or `token` query parameter (for EventSource)

**Frontend:**
1. Extracts token from URL on page load
2. Stores token in localStorage for persistence across page refreshes
3. Removes token from URL after storing (security best practice)
4. Sends token with all API requests (both fetch and EventSource)
5. Detects 401 responses and shows auth error UI
6. Disables all functionality when auth fails

## UX

When authentication fails, the user sees:
- 🔴 Red pill-shaped "⚠️ Auth failed" indicator in the TopBar
- Helpful tooltip: "Copy the full URL from your terminal (including ?token=...) and paste it into your browser"
- All buttons, toggles, and keyboard shortcuts disabled
- Editor becomes read-only

## Security

- Token is generated per server instance (new token on each restart)
- Token removed from URL after extraction (not visible in history)
- Token stored in localStorage (persists across page refreshes)
- All API endpoints protected except health check

## Test plan

- [x] Start pdit server, verify token appears in console URL
- [x] Open browser with token URL, verify app works
- [x] Test API without token → 401 Unauthorized
- [x] Test API with invalid token → 401 Unauthorized  
- [x] Test API with valid token (header) → 200 OK
- [x] Test API with valid token (query param) → 200 OK
- [x] Verify auth error banner appears on 401
- [x] Verify all buttons/shortcuts disabled when auth fails
- [x] Test token persistence across page refresh

Fixes #64