### PR TITLE
Update docs to use uv tool install

### DIFF
--- a/.claude/skills/pdit/SKILL.md
+++ b/.claude/skills/pdit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pdit
-description: "Collaborate with users running pdit, an interactive Python editor with inline execution results. Use when user mentions pdit, runs 'uv run pdit', or is doing collaborative Python development where they see live execution output in a browser."
+description: "Collaborate with users running pdit, an interactive Python editor with inline execution results. Use when user mentions pdit, runs 'pdit', or is doing collaborative Python development where they see live execution output in a browser."
 ---
 
 # pdit Collaboration
@@ -12,20 +12,8 @@ split-pane interface: code editor (left) and streaming execution results (right)
 
 **Starting pdit:**
 
-pdit runs using `uv run --with` so it's available without modifying the project:
-
 ```bash
-uv run --with git+https://github.com/vangberg/pdit@dist pdit script.py
-```
-
-**Note:** The `@dist` branch contains pre-built frontend assets, so no Node.js or build step is needed.
-
-**Upgrading pdit:**
-
-Since pdit is run with `--with`, it will fetch the latest version each time. To force a fresh fetch:
-
-```bash
-uv cache clean pdit
+pdit script.py
 ```
 
 **IMPORTANT: Run with `run_in_background: true` in the Bash tool so you can continue editing.**
@@ -40,7 +28,7 @@ Server runs on `localhost:8888`, browser opens automatically.
 **Exporting to HTML:**
 
 ```bash
-uv run --with git+https://github.com/vangberg/pdit@dist pdit --export script.py
+pdit --export script.py
 ```
 
 This executes the script and generates `script.html` - a self-contained HTML file that can be opened in any browser without a server.

--- a/README.md
+++ b/README.md
@@ -14,26 +14,40 @@ Pythonic live scripting.
 
 **Requirement**: [uv](https://github.com/astral-sh/uv)
 
+### Install as a tool (recommended)
+
 ```bash
-# Install from dist branch (recommended, includes pre-built assets)
-uv add git+https://github.com/vangberg/pdit@dist
+uv tool install git+https://github.com/vangberg/pdit@dist
+```
 
-# Or use directly with uvx
+This installs `pdit` globally, so you can run it from anywhere:
+
+```bash
+pdit script.py
+```
+
+### One-off usage with uvx
+
+```bash
 uvx --from git+https://github.com/vangberg/pdit@dist pdit script.py
+```
 
-# From cloned repo (for development)
+### Development install
+
+```bash
 git clone git@github.com:vangberg/pdit.git
 cd pdit
-uv pip install -e .
-uv run pdit script.py
+uv tool install . -e
 ```
+
+The `-e` flag creates an editable install, so changes to the source are reflected immediately.
 
 ## Usage
 
 Start pdit with a Python file:
 
 ```bash
-uv run pdit script.py
+pdit script.py
 ```
 
 This will:
@@ -44,7 +58,7 @@ This will:
 ### Options
 
 ```bash
-uv run pdit [OPTIONS] [SCRIPT]
+pdit [OPTIONS] [SCRIPT]
 
 Options:
   -e, --export        Export script to self-contained HTML file
@@ -60,16 +74,16 @@ Options:
 
 ```bash
 # Start with script
-uv run pdit analysis.py
+pdit analysis.py
 
 # Custom port
-uv run pdit --port 9000 script.py
+pdit --port 9000 script.py
 
 # Start without opening browser
-uv run pdit --no-browser script.py
+pdit --no-browser script.py
 
 # Just start the editor (no script)
-uv run pdit
+pdit
 ```
 
 ### Exporting
@@ -77,7 +91,7 @@ uv run pdit
 Export a script to a self-contained HTML file:
 
 ```bash
-uv run pdit --export script.py
+pdit --export script.py
 ```
 
 This executes the script and generates `script.html` with the output. The HTML file can be opened in any browser without a server.


### PR DESCRIPTION
## Summary
- Add `uv tool install` as the recommended installation method
- Update all examples to use `pdit` directly instead of `uv run pdit`
- Simplify skill instructions for Claude collaboration

## Test plan
- [x] Verified `uv tool install . -e` works locally
- [x] Verified `pdit --help` works after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)