### PR TITLE
Simplify WebSocket client + align reset

### DIFF
--- a/web/src/Script.tsx
+++ b/web/src/Script.tsx
@@ -150,8 +150,6 @@ export function Script({ scriptPath, onPathChange }: ScriptProps) {
       script: string,
       options?: { lineRange?: { from: number; to: number }; reset?: boolean },
     ): Promise<{ lastExecutedLineEnd?: number }> => {
-      // Extract script name from path (just the filename)
-      const scriptName = scriptPath ? scriptPath.split("/").pop() : undefined;
       let lastExecutedLineEnd: number | undefined;
 
       setIsExecuting(true);
@@ -159,7 +157,6 @@ export function Script({ scriptPath, onPathChange }: ScriptProps) {
         for await (const event of executeScript(script, {
           sessionId,
           ...options,
-          scriptName,
         })) {
           console.log("Execute event:", event);
 

--- a/web/src/execution-python.ts
+++ b/web/src/execution-python.ts
@@ -1,6 +1,6 @@
 /**
  * Main execution interface for Python code.
- * Uses Python server backend for local execution with SSE streaming.
+ * Uses Python server backend for local execution with WebSocket streaming.
  */
 
 import { PythonServerBackend } from './execution-backend-python';
@@ -17,7 +17,6 @@ const backend = new PythonServerBackend();
  * @param script - The Python code to execute
  * @param options.sessionId - Session ID for execution environment
  * @param options.lineRange - Optional line range to filter which statements to execute (1-based, inclusive)
- * @param options.scriptName - Optional script name for output context
  * @param options.reset - Optional flag to reset the execution environment before running
  */
 export async function* executeScript(
@@ -25,7 +24,6 @@ export async function* executeScript(
   options: {
     sessionId: string;
     lineRange?: { from: number; to: number };
-    scriptName?: string;
     reset?: boolean;
   }
 ) {


### PR DESCRIPTION
- Removes reconnection/polling/event-bus complexity from \n- Aligns protocol with backend (no unused cancel/scriptName/reset-in-execute);  now sends a separate reset message before execute\n- Updates execution tests to match  vs  semantics\n\nBase: 