### PR TITLE
Shutdown kernel sessions on exit

### DIFF
--- a/pdit/session.py
+++ b/pdit/session.py
@@ -267,3 +267,17 @@ def get_session(session_id: str) -> Session:
     if session_id not in _sessions:
         _sessions[session_id] = Session(session_id)
     return _sessions[session_id]
+
+
+def delete_session(session_id: str) -> None:
+    """Delete a session if it exists, shutting down its kernel."""
+    session = _sessions.pop(session_id, None)
+    if not session:
+        return
+    session.shutdown()
+
+
+def shutdown_all_sessions() -> None:
+    """Shutdown all active sessions."""
+    for session_id in list(_sessions.keys()):
+        delete_session(session_id)

--- a/tests/test_websocket_execution.py
+++ b/tests/test_websocket_execution.py
@@ -7,14 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from pdit.server import app
-from pdit.session import _sessions
-
-
-def delete_session(session_id: str):
-    """Delete a session and shutdown its kernel."""
-    if session_id in _sessions:
-        _sessions[session_id].shutdown()
-        del _sessions[session_id]
+from pdit.session import delete_session
 
 
 client = TestClient(app)


### PR DESCRIPTION
- Adds `shutdown_all_sessions()` and `delete_session()` to `pdit/session.py`
- Ensures kernels are shut down via FastAPI lifespan and `signal_shutdown()` in `pdit/server.py`
- Updates WebSocket tests to use public session helpers (no private `_sessions` import)

Base: claude/sse-to-websocket-migration-t2jik
